### PR TITLE
refactor: 마이페이지에서 하부 속성 눌렀을 때 재사용 될 화면 적용

### DIFF
--- a/lib/core/router/router.dart
+++ b/lib/core/router/router.dart
@@ -6,7 +6,8 @@ import 'package:cinemarket/features/login/screen/login_screen.dart';
 import 'package:cinemarket/features/main/screen/main_screen.dart';
 import 'package:cinemarket/features/movies/screen/movie_detail_screen.dart';
 import 'package:cinemarket/features/movies/screen/movies_screen.dart';
-import 'package:cinemarket/features/mypage/screen/mypage_screen.dart';
+import 'package:cinemarket/features/mypage/detail/my_page_detail_screen.dart';
+import 'package:cinemarket/features/mypage/screen/my_page_screen.dart';
 import 'package:cinemarket/features/search/screen/search_screen.dart';
 import 'package:cinemarket/features/signup/screen/sign_up_screen.dart';
 import 'package:go_router/go_router.dart';
@@ -64,6 +65,10 @@ final GoRouter router = GoRouter(
         final movieId = state.pathParameters['movieId']!;
         return MovieDetailScreen(movieId: movieId);
       },
+    ),
+    GoRoute(
+      path: '/mypage/detail',
+      builder: (context, state) => const MyPageDetailScreen(),
     ),
 
   ],

--- a/lib/features/mypage/detail/component/edit_profile_component.dart
+++ b/lib/features/mypage/detail/component/edit_profile_component.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class EditProfileComponent extends StatelessWidget {
+  const EditProfileComponent({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text(
+        '정보 수정 컴포넌트',
+        style: TextStyle(color: Colors.white),
+      ),
+    );
+  }
+}

--- a/lib/features/mypage/detail/component/my_review_component.dart
+++ b/lib/features/mypage/detail/component/my_review_component.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class MyReviewComponent extends StatelessWidget {
+  const MyReviewComponent({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text(
+        '리뷰 목록 컴포넌트',
+        style: TextStyle(color: Colors.white),
+      ),
+    );
+  }
+}

--- a/lib/features/mypage/detail/component/order_history_component.dart
+++ b/lib/features/mypage/detail/component/order_history_component.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class OrderHistoryComponent extends StatelessWidget {
+  const OrderHistoryComponent({super.key});
+  
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text(
+        '주문 내역 컴포넌트',
+        style: TextStyle(color: Colors.white),
+      ),
+    );
+  }
+}

--- a/lib/features/mypage/detail/my_page_detail_screen.dart
+++ b/lib/features/mypage/detail/my_page_detail_screen.dart
@@ -1,0 +1,43 @@
+import 'package:cinemarket/features/mypage/detail/component/edit_profile_component.dart';
+import 'package:cinemarket/features/mypage/detail/component/my_review_component.dart';
+import 'package:cinemarket/features/mypage/detail/component/order_history_component.dart';
+import 'package:cinemarket/widgets/common_app_bar.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class MyPageDetailScreen extends StatelessWidget {
+  const MyPageDetailScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final String menu = GoRouterState.of(context).extra as String? ?? '';
+
+    String title = '';
+    Widget bodyWidget;
+
+    switch (menu) {
+      case 'edit_profile':
+        title = '회원 정보 수정';
+        bodyWidget = const EditProfileComponent();
+        break;
+      case 'order_history':
+        title = '주문 내역';
+        bodyWidget = const OrderHistoryComponent();
+        break;
+      case 'my_review':
+        title = '리뷰 목록';
+        bodyWidget = const MyReviewComponent();
+        break;
+        
+      default:
+        title = '에러';
+        bodyWidget = const Center(child: Text('에러 페이지입니다.', style: TextStyle(color: Colors.white)));
+    }
+
+    return Scaffold(
+      backgroundColor: Colors.black,
+      appBar: CommonAppBar(title: title),
+      body: bodyWidget,
+    );
+  }
+}

--- a/lib/features/mypage/screen/my_page_screen.dart
+++ b/lib/features/mypage/screen/my_page_screen.dart
@@ -60,16 +60,15 @@ class _MyPageScreenState extends State<MyPageScreen> {
           textStyle: AppTextStyle.body,
           onTap: () {
             print('회원 정보 수정 클릭');
+            context.push('/mypage/detail', extra: 'edit_profile');
           },
         ),
         _buildMenuItem(
           title: '주문 내역',
           textStyle: AppTextStyle.body,
           onTap: () {
-            setState(() {
-              _hasToken = true;
-            });
             print('주문 내역 클릭');
+            context.push('/mypage/detail', extra: 'order_history');
           },
         ),
         _buildMenuItem(
@@ -77,6 +76,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
           textStyle: AppTextStyle.body,
           onTap: () {
             print('리뷰 목록 클릭');
+            context.push('/mypage/detail', extra: 'my_review');
           },
         ),
         _buildMenuItem(


### PR DESCRIPTION
> ✋ PR 명명 규칙
> 
> [브랜치명] 기능 제목  ex) [ui/f01] 찜 목록 화면 UI 구현 

<br>

## 👨‍💻 관련 화면 코드
- ui/U01

<br>

## ✨ 변경 내용 요약
- 어떤 기능을 추가/수정했는지 기술
재사용 뷰를 적용하여 마이페이지 하위 화면들을 extra값을 이용하여 그때그때 적용
<br>

## ✅ 체크리스트
- [x] 🙋 reviewer 설정 
- [x] 👨‍🔧 assignees 설정 
- [x] 🏷️ label 설정 
- [ ] 🖼️ 스크린샷 첨부 

<br>

## 💬 비고
- 

<br>

## 📸 스크린샷 
> ✋ 이미지 태그를 이용해 올려주세요 !
> ex) `<img src="your_image_url" width="45%" />`
