### PR TITLE
[feat/GOODS-003] 굿즈 상세 조회 통신 구현

### DIFF
--- a/lib/core/router/router.dart
+++ b/lib/core/router/router.dart
@@ -1,6 +1,7 @@
 import 'package:cinemarket/features/cart/screen/cart_screen.dart';
 import 'package:cinemarket/features/cart/widgets/cart_item_widgets.dart';
 import 'package:cinemarket/features/favorite/screen/favorite_screen.dart';
+import 'package:cinemarket/features/goods/model/goods.dart';
 import 'package:cinemarket/features/goods/screen/goods_detail_screen.dart';
 import 'package:cinemarket/features/goods/screen/goods_all_screen.dart';
 import 'package:cinemarket/features/goods/screen/goods_review_screen.dart';
@@ -57,10 +58,10 @@ final GoRouter router = GoRouter(
       builder: (context, state) => const CartScreen()
     ),
     GoRoute(
-      path: '/goods/detail',
+      path: '/goods/:goodsId',
       builder: (context, state) {
-        final item = state.extra as Map<String, dynamic>;
-        return GoodsDetailScreen(item: item);
+        final goodsId = state.pathParameters['goodsId']!;
+        return GoodsDetailScreen(goodsId: goodsId,);
       },
     ),
     GoRoute(

--- a/lib/features/goods/model/goods.dart
+++ b/lib/features/goods/model/goods.dart
@@ -12,9 +12,9 @@ class Goods {
   final int viewCount;
   final int orderCount;
   final int reviewCount;
-  final String createdBy;
+  final String createdAt;
   final GoodsImages images;
-  final ReviewStats reviewStats;
+  final ReviewStats? reviewStats;
   final bool isFavorite;
 
   Goods({
@@ -28,9 +28,9 @@ class Goods {
     required this.viewCount,
     required this.orderCount,
     required this.reviewCount,
-    required this.createdBy,
+    required this.createdAt,
     required this.images,
-    required this.reviewStats,
+    this.reviewStats,
     required this.isFavorite,
   });
 
@@ -38,7 +38,7 @@ class Goods {
     return Goods(
       id: json['id'],
       name: json['name'],
-      description: json['description'],
+      description: json['description'],  // todo: 기본값 처리 필요
       price: json['price'],
       stock: json['stock'],
       status: json['status'],
@@ -46,9 +46,11 @@ class Goods {
       viewCount: json['viewCount'],
       orderCount: json['orderCount'],
       reviewCount: json['reviewCount'],
-      createdBy: json['createdBy'],
-      images: GoodsImages.fromJson(json['images']),
-      reviewStats: ReviewStats.fromJson(json['reviewStats']),
+      createdAt: json['createdAt'],
+      images: GoodsImages.fromJson(json['images']),  // todo: 기본값 처리 필요
+      reviewStats: json['reviewStats'] != null
+      ? ReviewStats.fromJson(json['reviewStats'])
+      : null,
       isFavorite: json['isFavorite'],
     );
   }
@@ -56,6 +58,6 @@ class Goods {
   // 로그용 모델 출력
   @override
   String toString() {
-    return 'Goods(name: $name, price: $price, isFavorite: $isFavorite)';
+    return 'Goods( id: $id, name: $name, price: $price, isFavorite: $isFavorite,)';
   }
 }

--- a/lib/features/goods/model/goods_all_response.dart
+++ b/lib/features/goods/model/goods_all_response.dart
@@ -1,22 +1,22 @@
 import 'package:cinemarket/features/goods/model/goods.dart';
 import 'package:cinemarket/features/goods/model/pagination.dart';
 
-class GoodsResponse {
+class GoodsAllResponse {
   final bool success;
   final String message;
   final List<Goods> items;  // data -> items 구조 해체
   final Pagination pagination;
 
-  GoodsResponse({
+  GoodsAllResponse({
     required this.success,
     required this.message,
     required this.items,
     required this.pagination,
   });
 
-  factory GoodsResponse.fromJson(Map<String, dynamic> json) {
+  factory GoodsAllResponse.fromJson(Map<String, dynamic> json) {
     final data = json['data'];
-    return GoodsResponse(
+    return GoodsAllResponse(
       success: json['success'],
       message: json['message'],
       items: List<Goods>.from(

--- a/lib/features/goods/model/goods_detail_response.dart
+++ b/lib/features/goods/model/goods_detail_response.dart
@@ -1,0 +1,22 @@
+import 'package:cinemarket/features/goods/model/goods.dart';
+
+class GoodsDetailResponse {
+  final bool success;
+  final String message;
+  final Goods data;
+
+  GoodsDetailResponse({
+    required this.success,
+    required this.message,
+    required this.data,
+  });
+
+  factory GoodsDetailResponse.fromJson(Map<String, dynamic> json) {
+
+    return GoodsDetailResponse(
+      success: json['success'],
+      message: json['message'],
+      data: Goods.fromJson(json['data']),
+    );
+  }
+}

--- a/lib/features/goods/repository/goods_repository.dart
+++ b/lib/features/goods/repository/goods_repository.dart
@@ -1,11 +1,11 @@
 import 'package:cinemarket/features/goods/model/goods.dart';
 import 'package:cinemarket/features/goods/services/goods_service.dart';
 
-class GoodsAllRepository {
-  final GoodsAllService _goodsAllService;
+class GoodsRepository {
+  final GoodsService _goodsService;
 
-  GoodsAllRepository({GoodsAllService? goodsAllService})
-    : _goodsAllService = goodsAllService ?? GoodsAllService();
+  GoodsRepository({GoodsService? goodsAllService})
+    : _goodsService = goodsAllService ?? GoodsService();
 
   Future<List<Goods>> getAllGoodsList({
     int page = 1,
@@ -16,7 +16,7 @@ class GoodsAllRepository {
     String? sortBy,
     String sortOrder = 'desc',
   }) async {
-    final result = await _goodsAllService.getAllGoods(
+    final result = await _goodsService.getAllGoods(
       page: page,
       limit: limit,
       categoryId: categoryId,
@@ -27,5 +27,13 @@ class GoodsAllRepository {
     );
 
     return result.items;
+  }
+
+  Future<Goods> getDetailGoods({
+    required String goodsId,
+  }) async {
+    final result = await _goodsService.getDetailGoods(goodsId: goodsId,);
+
+    return result.data;
   }
 }

--- a/lib/features/goods/screen/goods_detail_screen.dart
+++ b/lib/features/goods/screen/goods_detail_screen.dart
@@ -1,4 +1,5 @@
 import 'package:cinemarket/core/theme/app_colors.dart';
+import 'package:cinemarket/features/goods/viewmodel/goods_detail_viewmodel.dart';
 import 'package:cinemarket/features/goods/widget/bottom_buttons_widget.dart';
 import 'package:cinemarket/features/goods/widget/common_tabs_content.dart';
 import 'package:cinemarket/features/goods/widget/header_goods_detail.dart';
@@ -9,40 +10,57 @@ import 'package:cinemarket/features/goods/widget/tabs_review.dart';
 import 'package:cinemarket/widgets/common_app_bar.dart';
 import 'package:cinemarket/widgets/common_tab_view.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
-// todo: 더미데이터도 그냥 굿즈아이템 객체를 만드는게 더 편하겠는데?
 class GoodsDetailScreen extends StatelessWidget {
-  final Map<String, dynamic> item;
+  final String goodsId;
 
-  const GoodsDetailScreen({super.key, required Map<String, dynamic> this.item});
+  const GoodsDetailScreen({super.key, required this.goodsId});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: CommonAppBar(title: item['goodsName']),
-      backgroundColor: AppColors.background,
-
-      body: Column(
-        children: [
-          Expanded(
-            child: NestedScrollView(
-              headerSliverBuilder:
-                  (context, _) => [HeaderGoodsDetail(item: item)],
-              body: CommonTabView(
-                tabTitles: tabTitles,
-                tabViews: [
-                  CommonTabsContent(widgets: getTabsDetailWidgets()),
-                  CommonTabsContent(widgets: getTabsReviewWidgets()),
-                  CommonTabsContent(widgets: getTabsDeliveryRefundWidgets()),
-                  CommonTabsContent(widgets: getTabsInquiryWidgets()),
-                ],
-              ),
-            ),
-          ),
-
-          const BottomButtonsWidget(),
-        ],
+    return FutureBuilder(
+      future: context.read<GoodsDetailViewmodel>().getDetailGoods(
+        goodsId: goodsId,
       ),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+        final viewModel = context.read<GoodsDetailViewmodel>();
+        final item = snapshot.data!;
+
+        return Scaffold(
+          appBar: CommonAppBar(title: item.name),
+          backgroundColor: AppColors.background,
+          body: Column(
+            children: [
+              Expanded(
+                child: NestedScrollView(
+                  headerSliverBuilder:
+                      (context, _) => [HeaderGoodsDetail(item: item)],
+                  body: CommonTabView(
+                    tabTitles: tabTitles,
+                    tabViews: [
+                      CommonTabsContent(
+                        widgets: getTabsDetailWidgets(item.description),
+                      ),
+                      CommonTabsContent(widgets: getTabsReviewWidgets()),
+                      CommonTabsContent(
+                        widgets: getTabsDeliveryRefundWidgets(),
+                      ),
+                      CommonTabsContent(widgets: getTabsInquiryWidgets()),
+                    ],
+                  ),
+                ),
+              ),
+              const BottomButtonsWidget(),
+            ],
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/features/goods/services/goods_service.dart
+++ b/lib/features/goods/services/goods_service.dart
@@ -2,10 +2,10 @@ import 'package:cinemarket/core/network/api_client.dart';
 import 'package:cinemarket/features/goods/model/goods_response.dart';
 import 'package:dio/dio.dart';
 
-class GoodsAllService {
+class GoodsService {
   final Dio _dio = ApiClient.dio;
 
-  Future<GoodsResponse> getAllGoods({
+  Future<GoodsAllResponse> getAllGoods({
     int page = 1,
     int limit = 20,
     String? categoryId,
@@ -28,8 +28,7 @@ class GoodsAllService {
         },
       );
 
-      return GoodsResponse.fromJson(response.data);
-
+      return GoodsAllResponse.fromJson(response.data);
     } on DioException catch (e) {
       final message = e.response?.data['message'] ?? e.message;
       throw Exception('상품 조회 실패: $message');

--- a/lib/features/goods/services/goods_service.dart
+++ b/lib/features/goods/services/goods_service.dart
@@ -1,5 +1,6 @@
 import 'package:cinemarket/core/network/api_client.dart';
-import 'package:cinemarket/features/goods/model/goods_response.dart';
+import 'package:cinemarket/features/goods/model/goods_all_response.dart';
+import 'package:cinemarket/features/goods/model/goods_detail_response.dart';
 import 'package:dio/dio.dart';
 
 class GoodsService {
@@ -13,7 +14,7 @@ class GoodsService {
     String? search,
     String? sortBy,
     String sortOrder = 'desc',
-}) async {
+  }) async {
     try {
       final response = await _dio.get(
         '/api/products',
@@ -32,6 +33,20 @@ class GoodsService {
     } on DioException catch (e) {
       final message = e.response?.data['message'] ?? e.message;
       throw Exception('상품 조회 실패: $message');
+    }
+  }
+
+  Future<GoodsDetailResponse> getDetailGoods({required String? goodsId}) async {
+    try {
+      final respones = await _dio.get(
+        '/api/products/$goodsId',
+      );
+
+      return GoodsDetailResponse.fromJson(respones.data);
+    } on DioException catch (e, stackTrace) {
+      final message = e.response?.data['message'] ?? e.message;
+
+      Error.throwWithStackTrace(Exception('상품상세 조회 실패: $message'), stackTrace);
     }
   }
 }

--- a/lib/features/goods/viewmodel/goods_all_viewmodel.dart
+++ b/lib/features/goods/viewmodel/goods_all_viewmodel.dart
@@ -3,16 +3,16 @@ import 'package:cinemarket/features/goods/repository/goods_repository.dart';
 import 'package:flutter/material.dart';
 
 class GoodsAllViewModel extends ChangeNotifier {
-  final GoodsAllRepository _goodsAllRepository;
+  final GoodsRepository _goodsRepository;
 
   List<Goods> goodsList = [];
 
-  GoodsAllViewModel({GoodsAllRepository? goodsAllRepository})
-    : _goodsAllRepository = goodsAllRepository ?? GoodsAllRepository();
+  GoodsAllViewModel({GoodsRepository? goodsRepository})
+    : _goodsRepository = goodsRepository ?? GoodsRepository();
 
   Future<void> getAllGoods() async {
     try {
-      goodsList = await _goodsAllRepository.getAllGoodsList();
+      goodsList = await _goodsRepository.getAllGoodsList();
       notifyListeners();
 
       // 로그 출력

--- a/lib/features/goods/viewmodel/goods_detail_viewmodel.dart
+++ b/lib/features/goods/viewmodel/goods_detail_viewmodel.dart
@@ -1,0 +1,35 @@
+import 'package:cinemarket/features/goods/model/goods.dart';
+import 'package:cinemarket/features/goods/repository/goods_repository.dart';
+import 'package:flutter/material.dart';
+
+class GoodsDetailViewmodel extends ChangeNotifier {
+
+  GoodsDetailViewmodel({GoodsRepository? goodsRepository})
+      : _goodsRepository = goodsRepository ?? GoodsRepository();
+  final GoodsRepository _goodsRepository;
+
+  Goods? _goods;
+  Goods get goods => _goods!;
+
+  Future<Goods> getDetailGoods({required String goodsId,}) async {
+    try {
+      _goods = await _goodsRepository.getDetailGoods(goodsId: goodsId);
+      notifyListeners();
+
+      // 로그 출력
+      print('😍😍😍');
+      print(goods);// 👍👍👍 toString()이 오버라이드되어 있어 보기 좋게 출력됨
+    } catch (e, stackTrace) {
+
+      print("😂😂😂 err");
+      print(e);
+      print('$stackTrace');
+      // 에러 처리
+    } finally {
+      print("😎😎😎 통과");
+    }
+
+    return _goods!;
+  }
+
+}

--- a/lib/features/goods/widget/header_goods_detail.dart
+++ b/lib/features/goods/widget/header_goods_detail.dart
@@ -1,9 +1,10 @@
 import 'package:cinemarket/core/theme/app_text_style.dart';
+import 'package:cinemarket/features/goods/model/goods.dart';
 import 'package:cinemarket/features/goods/widget/primary_image_widget.dart';
 import 'package:flutter/material.dart';
 
 class HeaderGoodsDetail extends StatelessWidget {
-  final Map<String, dynamic> item;
+  final Goods item;
 
   const HeaderGoodsDetail({super.key, required this.item});
 
@@ -16,8 +17,8 @@ class HeaderGoodsDetail extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             PrimaryImageWidget(
-              imageUrl: item['imageUrl'],
-              isFavorite: item['isFavorite'],
+              imageUrl: item.images.main,
+              isFavorite: item.isFavorite,
             ),
 
             const SizedBox(height: 8),
@@ -26,7 +27,7 @@ class HeaderGoodsDetail extends StatelessWidget {
               height: 60,
               child: ListView.builder(
                 scrollDirection: Axis.horizontal,
-                itemCount: dummyGoodsImages.length,
+                itemCount: item.images.sub.length,
                 itemBuilder: (context, index) {
                   return Padding(
                     padding: const EdgeInsets.only(right: 8),
@@ -35,7 +36,7 @@ class HeaderGoodsDetail extends StatelessWidget {
                       child: ClipRRect(
                         borderRadius: BorderRadius.circular(16),
                         child: Image.network(
-                          dummyGoodsImages[index],
+                          item.images.sub[index],
                           fit: BoxFit.cover,
                         ),
                       ),
@@ -62,8 +63,8 @@ class HeaderGoodsDetail extends StatelessWidget {
                 Column(
                   crossAxisAlignment: CrossAxisAlignment.end,
                   children: [
-                    Text(item['goodsName'], style: AppTextStyle.section),
-                    Text("${item['price']}", style: AppTextStyle.bodySmall),
+                    Text(item.name, style: AppTextStyle.section),
+                    Text('${item.price}', style: AppTextStyle.bodySmall),
                   ],
                 ),
               ],
@@ -74,10 +75,3 @@ class HeaderGoodsDetail extends StatelessWidget {
     );
   }
 }
-
-final List<String> dummyGoodsImages = [
-  'https://i.ebayimg.com/images/g/WgwAAOSw~qJnttY4/s-l1200.jpg',
-  'https://i.ebayimg.com/images/g/f1oAAOSwq~JnDljW/s-l1200.jpg',
-  'https://i.ebayimg.com/images/g/5RMAAOSwhlxnlJl4/s-l400.jpg',
-  'https://i.ebayimg.com/images/g/BzAAAeSweMtn22-l/s-l1200.png',
-];

--- a/lib/features/goods/widget/header_goods_detail.dart
+++ b/lib/features/goods/widget/header_goods_detail.dart
@@ -53,7 +53,7 @@ class HeaderGoodsDetail extends StatelessWidget {
                 Row(
                   children: [
                     const Icon(Icons.star_rate, color: Colors.yellow, size: 16),
-                    Text("${item['rating']}", style: AppTextStyle.bodySmall),
+                    Text('${item.reviewStats?.averageRating}', style: AppTextStyle.bodySmall),
                   ],
                 ),
 

--- a/lib/features/goods/widget/tabs_detail.dart
+++ b/lib/features/goods/widget/tabs_detail.dart
@@ -2,43 +2,12 @@ import 'package:cinemarket/core/theme/app_text_style.dart';
 import 'package:cinemarket/widgets/expandable_text.dart';
 import 'package:flutter/material.dart';
 
-List<Widget> getTabsDetailWidgets() {
+List<Widget> getTabsDetailWidgets(String description) {
   return [
     const Text('상세 설명', style: AppTextStyle.headline),
     SizedBox(height: 8,),
     ExpandableText(
-      textWidget: Text(veryLooooooooongText, style: AppTextStyle.bodySmall),
+      textWidget: Text(description, style: AppTextStyle.bodySmall),
     ),
   ];
 }
-
-final String veryLooooooooongText = '''
-『미키17』은 봉준호 감독의 첫 영어 SF 영화로, 동명의 소설 『Mickey7』(에드워드 애슈턴 작)을 원작으로 한다. 
-
-주인공 "미키"는 인류가 새로운 행성에 식민지를 건설하기 위해 파견한 소모성 인물, 일명 "디스포서블"이다. 그는 죽음을 반복하며 자신을 복제해 다시 살아나는 존재다.
-
-죽음의 공포가 일상인 미키는 열일곱 번째로 부활한 클론이다. 하지만 어느 날, 살아있는 전 클론인 "미키16"이 여전히 존재함을 알게 되며 혼란에 빠진다.
-
-이는 시스템에 대한 도전, 존재의 의미에 대한 질문, 그리고 '나는 누구인가'라는 철학적 고민으로 이어진다.
-
-주인공 역할은 로버트 패틴슨이 맡았으며, 나오미 애키, 토니 콜렛, 마크 러팔로 등이 출연한다.
-
-봉준호 감독은 이 작품을 통해 「기생충」 이후 할리우드에서의 새로운 도전을 시도하며, 특유의 사회적 메시지를 SF 장르에 녹여냈다.
-
-'디스포서블'이라는 개념은 현대 사회에서 인간의 도구화, 생명 경시 등의 문제를 투영한 설정으로 평가받고 있다.
-
-미키17은 철저한 관리 체계와 생존 전략 속에서도 인간성이 살아남을 수 있는가를 질문한다.
-
-'복제체'와 '원본'의 관계, 인류의 진보와 그 그림자에 대한 탐구가 핵심 테마다.
-
-영화는 2025년 개봉 예정이며, 전 세계적으로 큰 기대를 받고 있다.
-
-이번 작품은 봉 감독이 직접 각본을 쓰고 연출까지 맡은 프로젝트로, 그의 고유한 스타일이 더욱 깊게 배어있다.
-
-SF 장르 특유의 세계관과 철학적 서사를 동시에 즐기고 싶은 관객에게 강력히 추천되는 작품이다.
-
-예고편에서는 우주선, 외계 행성, 기계화된 인간, 충격적인 복제실 등 시각적으로 압도적인 장면들이 펼쳐진다.
-
-이 작품은 단순한 SF 블록버스터가 아니라, 인간 존재와 정체성의 문제를 던지는 깊이 있는 이야기다.
-
-''';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:cinemarket/features/goods/viewmodel/goods_all_viewmodel.dart';
+import 'package:cinemarket/features/goods/viewmodel/goods_detail_viewmodel.dart';
 import 'package:provider/provider.dart';
 import 'package:cinemarket/features/home/viewModel/home_viewmodel.dart';
 import 'package:flutter/material.dart';
@@ -20,6 +21,7 @@ class MyApp extends StatelessWidget {
       providers: [
         ChangeNotifierProvider(create: (_) => HomeViewModel()),
         ChangeNotifierProvider(create: (_) => GoodsAllViewModel()),
+        ChangeNotifierProvider(create: (_) => GoodsDetailViewmodel()),
       ],
       child: MaterialApp.router(title: 'CineMarket', routerConfig: router),
     );

--- a/lib/widgets/common_gridview.dart
+++ b/lib/widgets/common_gridview.dart
@@ -48,7 +48,7 @@ class CommonGridview<T> extends StatelessWidget {
               goodsName: item.name,
               movieName: item.id,
               price: '${item.price} 원',
-              rating: item.reviewStats.averageRating,
+              rating: item.reviewStats!.averageRating,
               reviewCount: item.reviewCount,
               isFavorite: item.isFavorite,
             ),

--- a/lib/widgets/common_gridview.dart
+++ b/lib/widgets/common_gridview.dart
@@ -41,7 +41,7 @@ class CommonGridview<T> extends StatelessWidget {
         if (item is Goods) {
           return GestureDetector(
             onTap: () {
-              context.push('/goods/detail', extra: item);
+              context.push('/goods/${item.id}', );
             },
             child: GoodsItem(
               imageUrl: item.images.main,


### PR DESCRIPTION
> ✋ PR 명명 규칙
> 
> [브랜치명] 기능 제목  ex) [ui/f01] 찜 목록 화면 UI 구현 

<br>

## 👨‍💻 관련 화면 코드
- g02

<br>

## ✨ 변경 내용 요약
- 굿즈 상세 조회 통신 구현
- 라우팅 경로를 path parameter 방식으로 변경 (`/goods/:goodsId`)
- 비동기 응답값 처리를 위한 `FutureBuilder` 구조 사용

<br>

## ✅ 체크리스트
- [x] 🙋 reviewer 설정 
- [x] 👨‍🔧 assignees 설정 
- [x] 🏷️ label 설정 
- [x] 🖼️ 스크린샷 첨부 

<br>

## 💬 비고
- UI 버그는 이후 fix 브랜치에서..

<br>

## 📸 스크린샷 
> ✋ 이미지 태그를 이용해 올려주세요 !
> ex) `<img src="your_image_url" width="45%" />`
<img src="https://github.com/user-attachments/assets/11436f64-3ca1-478b-ab6e-2555546d4626" width="45%" />
<img src="https://github.com/user-attachments/assets/929e309e-bc4d-4967-8942-30bdf958d41d" width="45%" />
