### PR TITLE
[fix/FAV-001] 비회원이 찜 추가 시 로그인 유도 화면으로 이동 기능 fix

### DIFF
--- a/lib/features/favorite/service/favorite_service.dart
+++ b/lib/features/favorite/service/favorite_service.dart
@@ -49,7 +49,8 @@ class FavoriteService {
 
     } on DioException catch (e) {
       final message = e.response?.data['message'] ?? e.message;
-      throw Exception('굿즈 찜 실패: $message');
+      Logger().i('굿즈 찜 실패: $message');
+      return false;
     }
   }
 }


### PR DESCRIPTION
- thorw로 인해 로그인 유도 UI 분기까지 도달하지 못함 따라서 thorw가 아닌 false return으로 변경

> ✋ PR 명명 규칙
> 
> [브랜치명] 기능 제목  ex) [ui/f01] 찜 목록 화면 UI 구현 

<br>

## 👨‍💻 관련 화면 코드
- f01

<br>

## ✨ 변경 내용 요약
- thorw로 인해 로그인 유도 UI 분기까지 도달하지 못함
따라서 thorw가 아닌 false return으로 변경

<br>

## ✅ 체크리스트
- [x] 🙋 reviewer 설정 
- [x] 👨‍🔧 assignees 설정 
- [x] 🏷️ label 설정 
- [x] 🖼️ 스크린샷 첨부 

<br>

## 💬 비고
- 

<br>

## 📸 스크린샷 
> ✋ 이미지 태그를 이용해 올려주세요 !
> ex) `<img src="your_image_url" width="45%" />`
<img src="https://github.com/user-attachments/assets/8a45a531-3444-4cab-b91a-f2e0914ace9f" width="45%" />