### PR TITLE
[fix/FAV-004] 영화 찜 통신 위치를 영화 상세 화면 한 개로 수정

### DIFF
--- a/lib/features/favorite/screen/favorite_screen.dart
+++ b/lib/features/favorite/screen/favorite_screen.dart
@@ -85,6 +85,7 @@ class _FavoriteScreenState extends State<FavoriteScreen> {
             itemType: ItemType.movie,
             // items: dummyMovies,
             items: viewModel.favoriteMovies,
+            isFavoriteScreen: true,
           ),
         ),
       ],

--- a/lib/widgets/common_gridview.dart
+++ b/lib/widgets/common_gridview.dart
@@ -10,6 +10,7 @@ import 'package:go_router/go_router.dart';
 class CommonGridview<T> extends StatelessWidget {
   final List<T> items;
   final ItemType itemType;
+  final bool isFavoriteScreen;
   final bool isInScrollView;
   final ScrollController? scrollController;
 
@@ -17,6 +18,7 @@ class CommonGridview<T> extends StatelessWidget {
     super.key,
     required this.itemType,
     required this.items,
+    this.isFavoriteScreen = false,
     this.isInScrollView = false,
     this.scrollController,
   });
@@ -94,6 +96,7 @@ class CommonGridview<T> extends StatelessWidget {
               providers: item.providers,
               isFavorite: false, //추후 즐겨찾기 연동?  // todo:
               movieId: item.id,
+              isFavoriteScreen: isFavoriteScreen,
             ),
           );
         }

--- a/lib/widgets/movie_item.dart
+++ b/lib/widgets/movie_item.dart
@@ -14,6 +14,7 @@ class MovieItem extends StatefulWidget {
   final List<Map<String, String>> providers;
   final bool isFavorite;
   final int movieId;
+  final bool isFavoriteScreen;
 
   const MovieItem({
     super.key,
@@ -23,6 +24,7 @@ class MovieItem extends StatefulWidget {
     required this.providers,
     required this.isFavorite,
     required this.movieId,
+    this.isFavoriteScreen = false,
   });
 
   @override
@@ -59,7 +61,7 @@ class _MovieItemState extends State<MovieItem> {
                       fit: BoxFit.cover,
                       width: double.infinity,
                       height: double.infinity,
-                      errorBuilder: (context,error,stackTrace) {
+                      errorBuilder: (context, error, stackTrace) {
                         return Image.asset(
                           'assets/images/default_poster.png',
                           fit: BoxFit.cover,
@@ -70,38 +72,39 @@ class _MovieItemState extends State<MovieItem> {
                     ),
                   ),
                 ),
-                Align(
-                  alignment: Alignment.bottomRight,
-                  child: IconButton(
-                    onPressed: () async {
-                      // 로그인 요청  // 하지 않는다면 바로 action 종료
-                      if (!await requireLoginBeforeAction(context)) return;
+                if (widget.isFavoriteScreen)
+                  Align(
+                    alignment: Alignment.bottomRight,
+                    child: IconButton(
+                      onPressed: () async {
+                        // 로그인 요청  // 하지 않는다면 바로 action 종료
+                        if (!await requireLoginBeforeAction(context)) return;
 
-                      if (await updateFavoriteStatus(
-                        movieId: widget.movieId.toString(),
-                      )) {
-                        if (!context.mounted) return;
+                        if (await updateFavoriteStatus(
+                          movieId: widget.movieId.toString(),
+                        )) {
+                          if (!context.mounted) return;
 
-                        setState(() => isFavorite = !isFavorite);
-                        CommonToast.show(
-                          context: context,
-                          message: isFavorite ? '찜 추가 완료 !' : '찜 삭제 완료 !',
-                          type: ToastificationType.success,
-                        );
-                      } else {
-                        CommonToast.show(
+                          setState(() => isFavorite = !isFavorite);
+                          CommonToast.show(
+                            context: context,
+                            message: isFavorite ? '찜 추가 완료 !' : '찜 삭제 완료 !',
+                            type: ToastificationType.success,
+                          );
+                        } else {
+                          CommonToast.show(
                             context: context,
                             message: '에러 발생',
                             type: ToastificationType.error,
-                        );
-                      }
-                    },
-                    icon: Icon(
-                      isFavorite ? Icons.favorite : Icons.favorite_border,
-                      color: Colors.red,
+                          );
+                        }
+                      },
+                      icon: Icon(
+                        isFavorite ? Icons.favorite : Icons.favorite_border,
+                        color: Colors.red,
+                      ),
                     ),
                   ),
-                ),
               ],
             ),
           ),
@@ -126,37 +129,47 @@ class _MovieItemState extends State<MovieItem> {
                   color: AppColors.textPrimary,
                 ),
                 const SizedBox(width: 4),
-                Text('${widget.cumulativeSales}', style: AppTextStyle.bodySmall),
+                Text(
+                  '${widget.cumulativeSales}',
+                  style: AppTextStyle.bodySmall,
+                ),
               ],
             ),
           ),
           const SizedBox(height: 2),
           Padding(
-            padding: const EdgeInsets.only(left: 4, bottom: 4,),
-            child: widget.providers.isNotEmpty
-              ? Row(
-                  children: widget.providers.map((provider) {
-                    //TMDB watcha 로고 오류 -> 네트워크 이미지로 대체
-                    final isWatcha = provider['providerName']?.toLowerCase() == 'watcha';
-                    final logoUrl = isWatcha
-                        ? 'https://play-lh.googleusercontent.com/vAkKvTtE8kdb0MWWxOVaqYVf0_suB-WMnfCR1MslBsGjhI49dAfF1IxcnhtpL3PnjVY'
-                        : provider['logoUrl'] ?? '';
+            padding: const EdgeInsets.only(left: 4, bottom: 4),
+            child:
+                widget.providers.isNotEmpty
+                    ? Row(
+                      children:
+                          widget.providers.map((provider) {
+                            //TMDB watcha 로고 오류 -> 네트워크 이미지로 대체
+                            final isWatcha =
+                                provider['providerName']?.toLowerCase() ==
+                                'watcha';
+                            final logoUrl =
+                                isWatcha
+                                    ? 'https://play-lh.googleusercontent.com/vAkKvTtE8kdb0MWWxOVaqYVf0_suB-WMnfCR1MslBsGjhI49dAfF1IxcnhtpL3PnjVY'
+                                    : provider['logoUrl'] ?? '';
 
-                    return Padding(
-                      padding: const EdgeInsets.only(right: 4),
-                      child: ClipRRect(
-                        borderRadius: BorderRadius.circular(4),
-                        child: Image.network(
-                          logoUrl,
-                          width: 15,
-                          height: 15,
-                          errorBuilder: (context, error, stackTrace) => const SizedBox(),
-                        ),
-                      ),
-                    );
-                  }).toList(),
-                )
-              : const SizedBox(height: 15,)
+                            return Padding(
+                              padding: const EdgeInsets.only(right: 4),
+                              child: ClipRRect(
+                                borderRadius: BorderRadius.circular(4),
+                                child: Image.network(
+                                  logoUrl,
+                                  width: 15,
+                                  height: 15,
+                                  errorBuilder:
+                                      (context, error, stackTrace) =>
+                                          const SizedBox(),
+                                ),
+                              ),
+                            );
+                          }).toList(),
+                    )
+                    : const SizedBox(height: 15),
           ),
         ],
       ),


### PR DESCRIPTION
- movie_item.dart의 경우 favorite_screen.dart에서의 진입이 아닌 경우 즐겨찾기 버튼 삭제

> ✋ PR 명명 규칙
> 
> [브랜치명] 기능 제목  ex) [ui/f01] 찜 목록 화면 UI 구현 

<br>

## 👨‍💻 관련 화면 코드
- f02 및 영화 찜 화면 전반

<br>

## ✨ 변경 내용 요약
- movie_item 내 분기 (영화 찜 목록 화면이 아닌 경우 찜 버튼 삭제)

<br>

## ✅ 체크리스트
- [ ] 🙋 reviewer 설정 
- [ ] 👨‍🔧 assignees 설정 
- [ ] 🏷️ label 설정 
- [ ] 🖼️ 스크린샷 첨부 

<br>

## 💬 비고
- 

<br>

## 📸 스크린샷 
> ✋ 이미지 태그를 이용해 올려주세요 !
> ex) `<img src="your_image_url" width="45%" />`
