### PR TITLE
[fix/soldout-g02] 품절 상태에서의 굿즈 상세 화면 구현

### DIFF
--- a/lib/features/goods/widget/header_goods_detail.dart
+++ b/lib/features/goods/widget/header_goods_detail.dart
@@ -21,6 +21,7 @@ class HeaderGoodsDetail extends StatelessWidget {
             PrimaryImageWidget(
               goodsId: item.id,
               imageUrl: item.images.main,
+              stock: item.stock,
               isFavorite: item.isFavorite,
               onTap: () => _showImageViewer(context, allImages, 0),
             ),

--- a/lib/features/goods/widget/primary_image_widget.dart
+++ b/lib/features/goods/widget/primary_image_widget.dart
@@ -1,9 +1,11 @@
+import 'package:cinemarket/core/theme/app_text_style.dart';
 import 'package:cinemarket/widgets/goods_item.dart';
 import 'package:flutter/material.dart';
 
 class PrimaryImageWidget extends StatefulWidget {
   final String goodsId;
   final String imageUrl;
+  final int stock;
   final bool isFavorite;
   final void Function() onTap;
 
@@ -11,6 +13,7 @@ class PrimaryImageWidget extends StatefulWidget {
     super.key,
     required this.goodsId,
     required this.imageUrl,
+    required this.stock,
     required this.isFavorite,
     required this.onTap,
   });
@@ -40,20 +43,47 @@ class _PrimaryImageWidgetState extends State<PrimaryImageWidget> {
             child: Image.network(widget.imageUrl, fit: BoxFit.cover),
           ),
         ),
+
         IconButton(
           icon: Icon(
             isFavorite ? Icons.favorite : Icons.favorite_border,
             color: Colors.red,
           ),
           onPressed: () {
-            toggleFavorite(context: context,
-                id: widget.goodsId,
-                isFavorite: isFavorite,
-                onStateChanged: (newState) {
-                  setState(() => isFavorite = newState);
-                });
+            toggleFavorite(
+              context: context,
+              id: widget.goodsId,
+              isFavorite: isFavorite,
+              onStateChanged: (newState) {
+                setState(() => isFavorite = newState);
+              },
+            );
           },
         ),
+
+        if (widget.stock == 0) ...[
+          Positioned.fill(
+            child: Container(
+              decoration: BoxDecoration(
+                color: const Color.fromRGBO(0, 0, 0, 0.5),
+                borderRadius: BorderRadius.circular(16),
+              ),
+            ),
+          ),
+
+          Positioned(
+            bottom: 8,
+            left: 8,
+            child: Container(
+              decoration: BoxDecoration(
+                color: const Color.fromRGBO(0, 0, 0, 0.5),
+                borderRadius: BorderRadius.circular(4),
+              ),
+              padding: const EdgeInsets.only(left: 4, right: 4, bottom: 2),
+              child: const Text('품절', style: AppTextStyle.bodyLarge),
+            ),
+          ),
+        ],
       ],
     );
   }


### PR DESCRIPTION
> ✋ PR 명명 규칙
> 
> [브랜치명] 기능 제목  ex) [ui/f01] 찜 목록 화면 UI 구현 

<br>

## 👨‍💻 관련 화면 코드
- g02

<br>

## ✨ 변경 내용 요약
- 굿즈 목록 화면에서의 품절과 같이 굿즈 상세 화면에서도 품절 시의 UI를 구현하였습니다.

<br>

## ✅ 체크리스트
- [ ] 🙋 reviewer 설정 
- [ ] 👨‍🔧 assignees 설정 
- [ ] 🏷️ label 설정 
- [ ] 🖼️ 스크린샷 첨부 

<br>

## 💬 비고
- 

<br>

## 📸 스크린샷 
> ✋ 이미지 태그를 이용해 올려주세요 !
> ex) `<img src="your_image_url" width="45%" />`
