### PR TITLE
[fix/g02-image-dialog-exit] 굿즈 상세 화면에서 이미지 다이얼로그에 닫기 버튼 추가

### DIFF
--- a/lib/features/goods/widget/header_goods_detail.dart
+++ b/lib/features/goods/widget/header_goods_detail.dart
@@ -58,9 +58,12 @@ class HeaderGoodsDetail extends StatelessWidget {
 
             const SizedBox(height: 8),
 
-            Text(item.name, style: AppTextStyle.section,
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,),
+            Text(
+              item.name,
+              style: AppTextStyle.section,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
 
             Row(
               crossAxisAlignment: CrossAxisAlignment.end,
@@ -99,19 +102,33 @@ void _showImageViewer(
       return Dialog(
         insetPadding: const EdgeInsets.all(16),
         backgroundColor: Colors.transparent,
-        child: SizedBox(
-          // height: 500,
-          width: 300,
-          child: PageView.builder(
-            controller: PageController(initialPage: initialIndex),
-            itemCount: images.length,
-            itemBuilder: (context, index) {
-              return InteractiveViewer(
-                // pinch-zoom 가능
-                child: Image.network(images[index], fit: BoxFit.contain),
-              );
-            },
-          ),
+        child: Stack(
+          children: [
+            SizedBox(
+              // height: 500,
+              width: double.infinity,
+              child: PageView.builder(
+                controller: PageController(initialPage: initialIndex),
+                itemCount: images.length,
+                itemBuilder: (context, index) {
+                  return InteractiveViewer(
+                    // pinch-zoom 가능
+                    child: Image.network(images[index], fit: BoxFit.contain),
+                  );
+                },
+              ),
+            ),
+            Positioned(
+              top: 0,
+              right: 0,
+              child: IconButton(
+                icon: const Icon(Icons.close, color: Colors.white),
+                onPressed: () {
+                  Navigator.of(context).pop();
+                },
+              ),
+            ),
+          ],
         ),
       );
     },


### PR DESCRIPTION
> ✋ PR 명명 규칙
> 
> [브랜치명] 기능 제목  ex) [ui/f01] 찜 목록 화면 UI 구현 

<br>

## 👨‍💻 관련 화면 코드
- g02

<br>

## ✨ 변경 내용 요약
-  굿즈 상세 화면에서 이미지 다이얼로그에 닫기 버튼 추가

<br>

## ✅ 체크리스트
- [ ] 🙋 reviewer 설정 
- [ ] 👨‍🔧 assignees 설정 
- [ ] 🏷️ label 설정 
- [ ] 🖼️ 스크린샷 첨부 

<br>

## 💬 비고
- 

<br>

## 📸 스크린샷 
> ✋ 이미지 태그를 이용해 올려주세요 !
> ex) `<img src="your_image_url" width="45%" />`
<img src="https://github.com/user-attachments/assets/7ff69665-b2ff-46b9-b019-ce6cd2cb6e3a" width="45%" />
