### PR TITLE
[fix/movie-fav-from-api-and-recommend-goods-fav] 영화 상세 화면에서 찜 상태 가져오기

### DIFF
--- a/lib/features/movies/repository/movie_detail_repository.dart
+++ b/lib/features/movies/repository/movie_detail_repository.dart
@@ -1,8 +1,8 @@
-import 'package:cinemarket/core/model/list_response.dart';
 import 'package:cinemarket/features/home/model/best_goods.dart';
 import 'package:cinemarket/features/movies/model/tmdb_movie_detail.dart';
 import 'package:cinemarket/features/movies/model/cast_member.dart';
 import 'package:cinemarket/features/movies/service/movies_service.dart';
+import 'package:logger/logger.dart';
 
 class MovieDetailRepository {
   final MoviesService _service = MoviesService();
@@ -36,5 +36,17 @@ class MovieDetailRepository {
     return _service.fetchProviders(movieId);
   }
 
+  Future<bool> getMovieIsLiked(String contentId) async {
+    final response = await _service.fetchMovieProducts(contentId);
+
+    final data = response.data;
+
+    final success = data['success'] == true;
+    if (!success) throw Exception(data['message'] ?? '영화 좋아요 불러오기 실패');
+
+    Logger().i('isLiked : ${data['data']?['isLiked']}');
+
+    return data['data']?['isLiked'] ?? false;
+  }
 
 }

--- a/lib/features/movies/screen/movie_detail_screen.dart
+++ b/lib/features/movies/screen/movie_detail_screen.dart
@@ -33,7 +33,8 @@ class _MovieDetailScreenState extends State<MovieDetailScreen> {
           (_) =>
               MovieDetailViewModel()
                 ..loadMovieDetail(int.parse(widget.movieId))
-                ..loadRecommendedGoods(widget.movieId),
+                ..loadRecommendedGoods(widget.movieId)
+                ..getMovieIsLiked(widget.movieId),
       child: Consumer<MovieDetailViewModel>(
         builder: (context, vm, child) {
           if (vm.isLoading) {
@@ -42,6 +43,7 @@ class _MovieDetailScreenState extends State<MovieDetailScreen> {
 
           final movieDetail = vm.movieDetail;
           final castList = vm.castList;
+          isFavorite = vm.isLiked;
 
           return Scaffold(
             appBar: const CommonAppBar(title: '영화 상세'),

--- a/lib/features/movies/viewmodel/movie_detail_viewmodel.dart
+++ b/lib/features/movies/viewmodel/movie_detail_viewmodel.dart
@@ -14,6 +14,8 @@ class MovieDetailViewModel extends ChangeNotifier {
   bool _isMovieLoading = false;
   bool _isGoodsLoading = false;
 
+  bool _isLiked = false;
+
   String? _error;
   bool? _success;
   String? _message;
@@ -23,6 +25,8 @@ class MovieDetailViewModel extends ChangeNotifier {
   List<BestGoods> get goodsList => _goodsList;
 
   bool get isLoading => _isMovieLoading || _isGoodsLoading;
+
+  bool get isLiked => _isLiked;
 
   String? get error => _error;
   bool? get success => _success;
@@ -66,5 +70,8 @@ class MovieDetailViewModel extends ChangeNotifier {
     }
   }
 
+  Future<void> getMovieIsLiked(String contentId) async {
+    _isLiked = await _repository.getMovieIsLiked(contentId);
+  }
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -149,10 +149,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -548,10 +548,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -849,10 +849,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
> ✋ PR 명명 규칙
> 
> [브랜치명] 기능 제목  ex) [ui/f01] 찜 목록 화면 UI 구현 

<br>

## 👨‍💻 관련 화면 코드
- mv02

<br>

## ✨ 변경 내용 요약
- 코드는 완성했으나 서버에서 값이 반영되지 않음.
- 추천 굿즈는 기존 코드 그대로 찜 상태 반영됨.
- `MovieDetailHeader`의 `onFavoriteToggle` 논의 필요
  - 현재 찜 클릭 시 무반응

<br>

## ✅ 체크리스트
- [ ] 🙋 reviewer 설정 
- [ ] 👨‍🔧 assignees 설정 
- [ ] 🏷️ label 설정 
- [ ] 🖼️ 스크린샷 첨부 

<br>

## 💬 비고
- 

<br>

## 📸 스크린샷 
> ✋ 이미지 태그를 이용해 올려주세요 !
> ex) `<img src="your_image_url" width="45%" />`
